### PR TITLE
Improve cheat detection system, proper exam termination and invalidate queries correctly

### DIFF
--- a/apps/web/src/components/admin/user/impersonate-user-btn.tsx
+++ b/apps/web/src/components/admin/user/impersonate-user-btn.tsx
@@ -4,6 +4,7 @@ import { Loader2, PlayCircle } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
+import { queryClient, queryUtils } from "@/utils/orpc";
 
 export const ImpersonateUserBtn = ({ userId }: { userId: string }) => {
 	const router = useRouter();
@@ -18,7 +19,9 @@ export const ImpersonateUserBtn = ({ userId }: { userId: string }) => {
 			if (data) {
 				toast.success(`Started ${data.user.name}'s session.`);
 
-				router.invalidate();
+				queryClient.invalidateQueries({
+					queryKey: queryUtils.key(),
+				});
 
 				router.navigate({
 					to: "/exams",

--- a/apps/web/src/components/admin/user/stop-impersonation-btn.tsx
+++ b/apps/web/src/components/admin/user/stop-impersonation-btn.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { authClient } from "@/lib/auth-client";
+import { queryClient, queryUtils } from "@/utils/orpc";
 
 export const StopImpersonationBtn = () => {
 	const router = useRouter();
@@ -30,7 +31,9 @@ export const StopImpersonationBtn = () => {
 				if (sessionData) {
 					toast.success(`Stopped ${sessionData.user.name}'s session.`);
 
-					router.invalidate();
+					queryClient.invalidateQueries({
+						queryKey: queryUtils.key(),
+					});
 
 					router.navigate({
 						to: "/dashboard/users/$userId/manage-user",

--- a/apps/web/src/components/user/attempt-exam-form.tsx
+++ b/apps/web/src/components/user/attempt-exam-form.tsx
@@ -38,7 +38,7 @@ import { useExamTimer } from "@/hooks/use-exam-timer";
 import { AttemptExamFormSchema } from "@/lib/schema/exam";
 import type { AttemptExamFormSchemaType } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { queryUtils } from "@/utils/orpc";
+import { queryClient, queryUtils } from "@/utils/orpc";
 
 export const AttemptExamForm = ({
 	examId,
@@ -76,8 +76,12 @@ export const AttemptExamForm = ({
 		queryUtils.user.submitExam.mutationOptions({
 			onSuccess: () => {
 				examSubmitted.current = true;
+
+				queryClient.invalidateQueries({
+					queryKey: queryUtils.user.key(),
+				});
+
 				toast.success("Exam submitted successfully!");
-				router.invalidate();
 				router.navigate({ to: "/exams" });
 			},
 			onError: (error) => {
@@ -90,8 +94,12 @@ export const AttemptExamForm = ({
 		queryUtils.user.terminateExam.mutationOptions({
 			onSuccess: () => {
 				examSubmitted.current = true;
+
+				queryClient.invalidateQueries({
+					queryKey: queryUtils.user.key(),
+				});
+
 				toast.error("Exam terminated due to suspicious activity.");
-				router.invalidate();
 				router.navigate({ to: "/exams" });
 			},
 			onError: (error) => {

--- a/apps/web/src/routes/_authenticated/(user-exam)/attempt-exam.tsx
+++ b/apps/web/src/routes/_authenticated/(user-exam)/attempt-exam.tsx
@@ -58,7 +58,10 @@ export const Route = createFileRoute(
 		};
 	},
 	component: RouteComponent,
-	onLeave: async ({ context: { orpcClient }, search }) => {
+	onLeave: async ({
+		context: { orpcClient, queryClient, queryUtils },
+		search,
+	}) => {
 		const { data: examAttemptStatusData } =
 			await orpcClient.user.getExamAttemptStatus({
 				examAttemptId: search.examAttemptId,
@@ -68,6 +71,7 @@ export const Route = createFileRoute(
 		}
 
 		const examAttemptStatus = examAttemptStatusData.status;
+
 		if (
 			examAttemptStatus === "in_progress" ||
 			examAttemptStatus === "started"
@@ -76,6 +80,10 @@ export const Route = createFileRoute(
 				examId: search.examId,
 				examAttemptId: search.examAttemptId,
 				reason: "User navigated within the app.",
+			});
+
+			queryClient.invalidateQueries({
+				queryKey: queryUtils.user.key(),
 			});
 		}
 	},

--- a/apps/web/src/routes/_authenticated/(user-exam)/attempt-exam.tsx
+++ b/apps/web/src/routes/_authenticated/(user-exam)/attempt-exam.tsx
@@ -59,11 +59,25 @@ export const Route = createFileRoute(
 	},
 	component: RouteComponent,
 	onLeave: async ({ context: { orpcClient }, search }) => {
-		await orpcClient.user.terminateExam({
-			examId: search.examId,
-			examAttemptId: search.examAttemptId,
-			reason: "User navigated within the app.",
-		});
+		const { data: examAttemptStatusData } =
+			await orpcClient.user.getExamAttemptStatus({
+				examAttemptId: search.examAttemptId,
+			});
+		if (examAttemptStatusData?.status === undefined) {
+			return;
+		}
+
+		const examAttemptStatus = examAttemptStatusData.status;
+		if (
+			examAttemptStatus === "in_progress" ||
+			examAttemptStatus === "started"
+		) {
+			await orpcClient.user.terminateExam({
+				examId: search.examId,
+				examAttemptId: search.examAttemptId,
+				reason: "User navigated within the app.",
+			});
+		}
 	},
 });
 


### PR DESCRIPTION
This pull request updates how client-side data is invalidated after user actions, replacing the previous use of `router.invalidate()` with more targeted cache invalidation using `queryClient.invalidateQueries`. This ensures that user and admin data is refreshed correctly after impersonation or exam actions, and improves reliability when navigating between pages. Additionally, the exam route's `onLeave` handler now checks the exam attempt status before terminating an exam and invalidates relevant queries accordingly.

**Improvements to cache invalidation and data consistency:**

* Replaced calls to `router.invalidate()` with `queryClient.invalidateQueries` using appropriate `queryKey` values after starting or stopping user impersonation in `impersonate-user-btn.tsx` and `stop-impersonation-btn.tsx`. [[1]](diffhunk://#diff-07bb93c81855a59757e5b22ee33d6f9b1975f62e40812f6905b651b27793f7d7L21-R24) [[2]](diffhunk://#diff-5b24b26af7cca9921c00f793f87ad6e0cde46cdd62e24e613de17853d9a6b51aL33-R36)
* Updated exam submission and termination handlers in `attempt-exam-form.tsx` to invalidate user queries with `queryClient.invalidateQueries`, ensuring user data is refreshed after these actions. [[1]](diffhunk://#diff-20f7455727802edb3665854cc753324b9cc34c1b3ea5465c69d9a0c311cd1357R79-L80) [[2]](diffhunk://#diff-20f7455727802edb3665854cc753324b9cc34c1b3ea5465c69d9a0c311cd1357R97-L94)

**Enhancements to exam attempt route logic:**

* Modified the `onLeave` handler in the exam attempt route to check the current exam attempt status before calling the termination mutation, and to invalidate user queries if the exam is terminated.

**Codebase consistency:**

* Added `queryClient` imports to relevant files to support the new cache invalidation logic. [[1]](diffhunk://#diff-07bb93c81855a59757e5b22ee33d6f9b1975f62e40812f6905b651b27793f7d7R7) [[2]](diffhunk://#diff-5b24b26af7cca9921c00f793f87ad6e0cde46cdd62e24e613de17853d9a6b51aR8) [[3]](diffhunk://#diff-20f7455727802edb3665854cc753324b9cc34c1b3ea5465c69d9a0c311cd1357L41-R41)