### PR TITLE
show termination reason in user exam info page

### DIFF
--- a/apps/server/src/lib/schema/exam.ts
+++ b/apps/server/src/lib/schema/exam.ts
@@ -231,6 +231,7 @@ export const GetUserExamsDataOutput = z.object({
 			attempt: z.number(),
 			timeSpent: z.number(),
 			maxAttempts: z.number(),
+			terminationReason: z.string().nullable(),
 		}),
 	),
 });

--- a/apps/server/src/routers/admin/user/exam.ts
+++ b/apps/server/src/routers/admin/user/exam.ts
@@ -180,6 +180,7 @@ export const adminUserExamRouter = {
 					attempt: sql<number>`COALESCE(${examAttempt.attemptNumber}, 0)`,
 					timeSpent: sql<number>`COALESCE(${examAttempt.timeSpent}, 0)`,
 					maxAttempts: userExam.maxAttempts,
+					terminationReason: examAttempt.terminationReason,
 				})
 				.from(userExam)
 				.innerJoin(exam, eq(userExam.examId, exam.id))

--- a/apps/web/src/components/admin/user/user-exams-table.tsx
+++ b/apps/web/src/components/admin/user/user-exams-table.tsx
@@ -11,7 +11,6 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuLabel,
-	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -90,7 +89,7 @@ const getColumns = (
 									<Info className="h-4 w-4 text-muted-foreground" />
 								</TooltipTrigger>
 								<TooltipContent>
-									{/* <p>{latestAttempt.terminationReason}</p> */}
+									<p>Cheating Detected: {row.original.terminationReason}</p>
 								</TooltipContent>
 							</Tooltip>
 						</TooltipProvider>

--- a/apps/web/src/routes/_authenticated/(user)/certificates.tsx
+++ b/apps/web/src/routes/_authenticated/(user)/certificates.tsx
@@ -1,9 +1,0 @@
-import { createFileRoute } from "@tanstack/react-router";
-
-export const Route = createFileRoute("/_authenticated/(user)/certificates")({
-	component: RouteComponent,
-});
-
-function RouteComponent() {
-	return <div>Hello "/_authenticated/(user)/certificates"!</div>;
-}


### PR DESCRIPTION
This pull request introduces support for displaying the exam termination reason (such as cheating detection) in the admin user exams table. It adds the necessary backend and frontend changes to store, retrieve, and display this information, and also removes an unused file.

Backend and Data Model Updates:

* Added a new nullable string field `terminationReason` to the `GetUserExamsDataOutput` schema in `exam.ts`, allowing exam attempts to record the reason for termination.
* Updated the admin user exam router to include the `terminationReason` field when returning exam attempt data.

Frontend Changes:

* Displayed the `terminationReason` in the tooltip of the admin user exams table, showing "Cheating Detected: {terminationReason}" for relevant attempts.
* Removed the unused `DropdownMenuSeparator` import from `user-exams-table.tsx` to clean up the code.

Cleanup:

* Deleted the unused certificates route file `certificates.tsx` from the user routes, removing dead code.